### PR TITLE
Update build.sh for gcc-5 on arch

### DIFF
--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -100,12 +100,12 @@ fi
 # might break the entry above to find gcc- on arm
 if [ -f "/etc/arch-release" ]; then
     if [ -f "/usr/bin/gcc-5" ]; then
-    CC=gcc-5
-    CXX=g++-5
+      CC=gcc-5
+      CXX=g++-5
+    else
+      echo 'gcc5 required, please install using "sudo pacman -S gss5"'
+      exit 1
     fi
-else
-echo 'gcc5 required, please install using "sudo pacman -S gss5"'
-exit 1
 fi
 
 PREFIX="$(pwd)/depends/$BUILD/"

--- a/zcutil/build.sh
+++ b/zcutil/build.sh
@@ -96,6 +96,18 @@ then
     shift
 fi
 
+# Arch workaround for gcc 7
+# might break the entry above to find gcc- on arm
+if [ -f "/etc/arch-release" ]; then
+    if [ -f "/usr/bin/gcc-5" ]; then
+    CC=gcc-5
+    CXX=g++-5
+    fi
+else
+echo 'gcc5 required, please install using "sudo pacman -S gss5"'
+exit 1
+fi
+
 PREFIX="$(pwd)/depends/$BUILD/"
 
 eval "$MAKE" --version


### PR DESCRIPTION
if /etc/arch-release then we will check for gcc5 and use it if found, otherwise we will error out due to failed deps

This is counter the the logic [here](https://github.com/madbuda/hush/blob/547c0aa7e0acecafe7bc991d1e08c0ad7af0e466/zcutil/build.sh#L20)

This may prevent building on arm
fixes #2 