### PR TITLE
Removing founders reward

### DIFF
--- a/src/metrics.cpp
+++ b/src/metrics.cpp
@@ -329,9 +329,6 @@ int printMetrics(size_t cols, bool mining)
                         chainActive.Contains(mapBlockIndex[hash])) {
                     int height = mapBlockIndex[hash]->nHeight;
                     CAmount subsidy = GetBlockSubsidy(height, consensusParams);
-                    if ((height > 0) && (height <= consensusParams.GetLastFoundersRewardBlockHeight())) {
-                        subsidy -= subsidy/5;
-                    }
                     if (std::max(0, COINBASE_MATURITY - (tipHeight - height)) > 0) {
                         immature += subsidy;
                     } else {


### PR DESCRIPTION
In metrics founders reward was still counted resulting on displaying 10 mined HUSH instead of actual 12.5 HUSH.