### PR TITLE
Use CTransaction isNull method instead of &tx!=0 which is always true

### DIFF
--- a/qa/rpc-tests/dpow.py
+++ b/qa/rpc-tests/dpow.py
@@ -25,12 +25,13 @@ class DPoWTest(BitcoinTestFramework):
         self.nodes[0].generate(3)
         rpc = self.nodes[0]
 
-        # Verify that basic RPC functions exist and work
-        result = rpc.calc_MoM(2,20)
-        print result
-
 	result = rpc.getinfo()
-	assert result.notarized,42
+	print result
+	# TODO: actually do notarizations on regtest and test for specific data
+	# TODO: does this have mainnet values somehow?
+	assert(result['notarized'] >= 0)
+	assert(result['notarizedhash'])
+	assert(result['notarizedtxid'])
 
 if __name__ == '__main__':
     DPoWTest().main()

--- a/src/komodo_validation011.h
+++ b/src/komodo_validation011.h
@@ -999,7 +999,6 @@ int32_t komodo_notarizeddata(int32_t nHeight,uint256 *notarized_hashp,uint256 *n
 void komodo_notarized_update(int32_t nHeight,int32_t notarized_height,uint256 notarized_hash,uint256 notarized_desttxid,uint256 MoM,int32_t MoMdepth)
 {
     static int didinit; static uint256 zero; static FILE *fp; CBlockIndex *pindex; struct notarized_checkpoint *np,N; long fpos;
-	LogPrintf("dpow: komodod_notarized_update\n");
     if ( didinit == 0 )
     {
         char fname[512];int32_t latestht = 0;
@@ -1094,7 +1093,8 @@ int32_t komodo_checkpoint(int32_t *notarized_heightp,int32_t nHeight,uint256 has
     if ( notarized_height >= 0 && notarized_height <= pindex->nHeight && mapBlockIndex.count(notarized_hash) != 0 )
     {
         notary = mapBlockIndex[notarized_hash];
-        printf("nHeight.%d -> (%d %s)\n",pindex->nHeight,notarized_height,notarized_hash.ToString().c_str());
+        if ( IS_NOTARY )
+            printf("nHeight.%d -> (%d %s)\n",pindex->nHeight,notarized_height,notarized_hash.ToString().c_str());
         if ( notary->nHeight == notarized_height ) // if notarized_hash not in chain, reorg
         {
             if ( nHeight < notarized_height )

--- a/src/komodo_validation011.h
+++ b/src/komodo_validation011.h
@@ -108,20 +108,18 @@ int32_t gettxout_scriptPubKey(int32_t height,uint8_t *scriptPubKey,int32_t maxsi
         }
     }
 
-    if ( &tx != 0 && n >= 0 && n < (int32_t)tx.vout.size() )
+    if ( !tx.IsNull() && n >= 0 && n < (int32_t)tx.vout.size() )
     {
         ptr = (uint8_t *)tx.vout[n].scriptPubKey.data();
         m = tx.vout[n].scriptPubKey.size();
 
         for (i=0; i<maxsize&&i<m; i++) {
-			//fprintf(stderr,"%02x",ptr[i]);
             scriptPubKey[i] = ptr[i];
-		}
-	    //fprintf(stderr,"\n");
+        }
         fprintf(stderr,"got scriptPubKey[%d] via rawtransaction ht.%d %s\n",m,height,txid.GetHex().c_str());
         return(i);
     }
-    else if ( &tx != 0 )
+    else if ( !tx.IsNull() )
         fprintf(stderr,"gettxout_scriptPubKey ht.%d n.%d > voutsize.%d\n",height,n,(int32_t)tx.vout.size());
 
     return(-1);
@@ -776,7 +774,7 @@ int32_t komodo_init()
     decode_hex(NOTARY_PUBKEY33,33,(char *)NOTARY_PUBKEY.c_str());
     if ( GetBoolArg("-txindex", DEFAULT_TXINDEX) == 0 )
     {
-        fprintf(stderr,"txindex is off, import notary pubkeys\n");
+        //fprintf(stderr,"txindex is off, import notary pubkeys\n");
         KOMODO_NEEDPUBKEYS = 1;
         KOMODO_TXINDEX = 0;
     }


### PR DESCRIPTION
This is an actual meaningful check, thanks for pointing this out @FireMartZ 

Also added some basic passing tests which look for `notarized` fields in `getinfo` output