### PR TITLE
Isolate notarization data for testnet + regtest to different files

### DIFF
--- a/qa/rpc-tests/dpow.py
+++ b/qa/rpc-tests/dpow.py
@@ -25,12 +25,13 @@ class DPoWTest(BitcoinTestFramework):
         self.nodes[0].generate(3)
         rpc = self.nodes[0]
 
-        # Verify that basic RPC functions exist and work
-        result = rpc.calc_MoM(2,20)
-        print result
-
 	result = rpc.getinfo()
-	assert result.notarized,42
+	print result
+	# TODO: actually do notarizations on regtest and test for specific data
+	# TODO: does this have mainnet values somehow?
+	assert(result['notarized'] >= 0)
+	assert(result['notarizedhash'])
+	assert(result['notarizedtxid'])
 
 if __name__ == '__main__':
     DPoWTest().main()

--- a/qa/rpc-tests/dpow.py
+++ b/qa/rpc-tests/dpow.py
@@ -28,9 +28,10 @@ class DPoWTest(BitcoinTestFramework):
 	result = rpc.getinfo()
 	print result
 	# TODO: actually do notarizations on regtest and test for specific data
-	assert(result['notarized'] >= 0)
-	assert(result['notarizedhash'])
-	assert(result['notarizedtxid'])
+	# regtest should have no notarization data, this test makes sure we do not see mainnet values as well!
+	assert_equal(result['notarized'],0)
+	assert_equal(result['notarizedhash'],'0000000000000000000000000000000000000000000000000000000000000000')
+	assert_equal(result['notarizedtxid'],'0000000000000000000000000000000000000000000000000000000000000000')
 
 if __name__ == '__main__':
     DPoWTest().main()

--- a/qa/rpc-tests/dpow.py
+++ b/qa/rpc-tests/dpow.py
@@ -28,7 +28,6 @@ class DPoWTest(BitcoinTestFramework):
 	result = rpc.getinfo()
 	print result
 	# TODO: actually do notarizations on regtest and test for specific data
-	# TODO: does this have mainnet values somehow?
 	assert(result['notarized'] >= 0)
 	assert(result['notarizedhash'])
 	assert(result['notarizedtxid'])

--- a/src/komodo_validation011.h
+++ b/src/komodo_validation011.h
@@ -54,6 +54,7 @@
 }*/
 
 #include <wallet/wallet.h>
+#include <chainparams.h>
 #include <base58.h>
 
 #define SATOSHIDEN ((uint64_t)100000000L)
@@ -1001,17 +1002,19 @@ int32_t komodo_notarizeddata(int32_t nHeight,uint256 *notarized_hashp,uint256 *n
 void komodo_notarized_update(int32_t nHeight,int32_t notarized_height,uint256 notarized_hash,uint256 notarized_desttxid,uint256 MoM,int32_t MoMdepth)
 {
     static int didinit; static uint256 zero; static FILE *fp; CBlockIndex *pindex; struct notarized_checkpoint *np,N; long fpos;
-	LogPrintf("dpow: komodod_notarized_update\n");
     if ( didinit == 0 )
     {
         char fname[512];int32_t latestht = 0;
         //decode_hex(NOTARY_PUBKEY33,33,(char *)NOTARY_PUBKEY.c_str());
         pthread_mutex_init(&komodo_mutex,NULL);
+        std::string suffix = Params().NetworkIDString() == "mainnet" ? "" : "_" + Params.NetworkIDString();
+        std::string sep;
 #ifdef _WIN32
-        sprintf(fname,"%s\\notarizations",GetDefaultDataDir().string().c_str());
+        sep = "\\";
 #else
-        sprintf(fname,"%s/notarizations",GetDefaultDataDir().string().c_str());
+        sep = "/";
 #endif
+        sprintf(fname,"%s%snotarizations%s",GetDefaultDataDir().string().c_str(), sep.c_str(), suffix.c_str());
         LogPrintf("dpow: fname.(%s)\n",fname);
         if ( (fp= fopen(fname,"rb+")) == 0 )
             fp = fopen(fname,"wb+");

--- a/src/komodo_validation011.h
+++ b/src/komodo_validation011.h
@@ -1007,7 +1007,7 @@ void komodo_notarized_update(int32_t nHeight,int32_t notarized_height,uint256 no
         char fname[512];int32_t latestht = 0;
         //decode_hex(NOTARY_PUBKEY33,33,(char *)NOTARY_PUBKEY.c_str());
         pthread_mutex_init(&komodo_mutex,NULL);
-        std::string suffix = Params().NetworkIDString() == "mainnet" ? "" : "_" + Params.NetworkIDString();
+        std::string suffix = Params().NetworkIDString() == "main" ? "" : "_" + Params().NetworkIDString();
         std::string sep;
 #ifdef _WIN32
         sep = "\\";
@@ -1048,7 +1048,7 @@ void komodo_notarized_update(int32_t nHeight,int32_t notarized_height,uint256 no
     }
     if ( notarized_height == 0 )
 	{
-        LogPrintf("dpow: notarized_height=0, aborting\n");
+        //LogPrintf("dpow: notarized_height=0, aborting\n");
         return;
 	}
     if ( notarized_height >= nHeight )
@@ -1071,7 +1071,7 @@ void komodo_notarized_update(int32_t nHeight,int32_t notarized_height,uint256 no
     NOTARIZED_HEIGHT = np->notarized_height = notarized_height;
     NOTARIZED_HASH = np->notarized_hash = notarized_hash;
     NOTARIZED_DESTTXID = np->notarized_desttxid = notarized_desttxid;
-    LogPrintf("dpow: NOTARIZED (HEIGHT,HASH,DESTTXID) = (%d, %s, %s)\n", NOTARIZED_HEIGHT, NOTARIZED_HASH.GetHex().c_str(), NOTARIZED_DESTTXID.GetHex().c_str());
+    LogPrintf("dpow: komodo_notarized_update NOTARIZED (HEIGHT,HASH,DESTTXID) = (%d, %s, %s)\n", NOTARIZED_HEIGHT, NOTARIZED_HASH.GetHex().c_str(), NOTARIZED_DESTTXID.GetHex().c_str());
     if ( MoM != zero && MoMdepth > 0 )
     {
         NOTARIZED_MOM = np->MoM = MoM;


### PR DESCRIPTION
I noticed that regtest tests could see the mainnet notarization data, which prompted this change. The result of `getinfo` on regtest mode made no sense, as it said there were 3 blocks total but the last notarized block was 386686 and gave mainnet notarization txid and hash, which are invalid on regtest.

* Isolates all NetworkID's to their own notarization data file
* Prevents regtest mode modifying mainnet data and vice versa
* This leaves the filename unchanged for mainnet, but for other networks, it will look like `notarizations_regtest`

To verify this works, I deleted all notarizations files, then ran `./qa/pull-tester/rpc-tests.sh dpow` and verified that `~/.hush/notarizations_regtest` existed and `~/.hush/notarizations` had not been created.