### PR TITLE
Fix Hush notarizations

### DIFF
--- a/src/komodo_validation011.h
+++ b/src/komodo_validation011.h
@@ -1195,7 +1195,7 @@ void komodo_connectblock(CBlockIndex *pindex,CBlock& block)
     if ( pindex != 0 )
     {
         height = pindex->nHeight;
-        //txn_count = block.vtx.size();
+        txn_count = block.vtx.size();
         //fprintf(stderr, "txn_count=%d\n", txn_count);
         for (i=0; i<txn_count; i++)
         {

--- a/src/komodo_validation011.h
+++ b/src/komodo_validation011.h
@@ -1065,7 +1065,7 @@ void komodo_notarized_update(int32_t nHeight,int32_t notarized_height,uint256 no
     NOTARIZED_HEIGHT = np->notarized_height = notarized_height;
     NOTARIZED_HASH = np->notarized_hash = notarized_hash;
     NOTARIZED_DESTTXID = np->notarized_desttxid = notarized_desttxid;
-    LogPrintf("dpow: NOTARIZED (HEIGHT,HASH,DESTTXID) = (%d, %s, %s)\n", NOTARIZED_HEIGHT, NOTARIZED_HASH.GetHex().c_str(), NOTARIZED_DESTTXID.GetHex().c_str());
+    //LogPrintf("dpow: NOTARIZED (HEIGHT,HASH,DESTTXID) = (%d, %s, %s)\n", NOTARIZED_HEIGHT, NOTARIZED_HASH.GetHex().c_str(), NOTARIZED_DESTTXID.GetHex().c_str());
     if ( MoM != zero && MoMdepth > 0 )
     {
         NOTARIZED_MOM = np->MoM = MoM;


### PR DESCRIPTION
This code is running on Chainstrike Notary Node and fixes the bug where nodes do not sync with the network notarization data. `txn_count` was never initialized and happened to always be zero, which skipped important code 😿

Example happy debug.log lines:
```
2018-10-02 20:50:38 dpow: komodo_notarized_update nHeight.389077 notarized_height.389074 prev.389068
2018-10-02 20:50:38 dpow: HUSH ht.389077 NOTARIZED.389074 0000000090ecd5d3d0aaefa9e6d1e5c546b411f192607b1a455fc308d9632cdc KMDTXID.e755ea2e4e509653738d5672650460e52fbcf1cbeb82e13e8974695b5cb534e5 lens.(73 75)
2018-10-02 20:50:38 dpow: [HUSH] ht.389077 txi.2 signedmask.40c05b0465000000 numvins.13 numvouts.2 notarized.1 special.1
```
Example happy getinfo:
```
$ ./src/hush-cli getinfo
{
  "version": 1001450,
  "protocolversion": 170002,
  "walletversion": 60000,
  "balance": 7.99250000,
  "blocks": 389065,
  "timeoffset": 0,
  "connections": 9,
  "tls_connections": 2,
  "proxy": "",
  "difficulty": 222498227.8839397,
  "testnet": false,
  "keypoololdest": 1537032541,
  "keypoolsize": 101,
  "paytxfee": 0.00000000,
  "relayfee": 0.00000100,
  "errors": "",
  "notarizedhash": "000000055dc041e6723b0f57226fa0f2cbc0bdc65d22fc5155caea073f9c003e",
  "notarizedtxid": "a725122efe6a3c76eb8df171dffd4d0739c0b8c67ede58b31715b9aec7ba5c51",
  "notarized": 389062
} 
```

NOTE: Notarization data is not instantly available when a node starts, you will need to wait until your node sees a notarization transaction for your local node data to be updated and then be visible via getinfo.