### PR TITLE
Update of Hush sw dependencies - libsodium 1.0.16

### DIFF
--- a/depends/packages/libsodium.mk
+++ b/depends/packages/libsodium.mk
@@ -1,8 +1,8 @@
 package=libsodium
-$(package)_version=1.0.11
+$(package)_version=1.0.16
 $(package)_download_path=https://download.libsodium.org/libsodium/releases/
-$(package)_file_name=libsodium-1.0.11.tar.gz
-$(package)_sha256_hash=a14549db3c49f6ae2170cbbf4664bd48ace50681045e8dbea7c8d9fb96f9c765
+$(package)_file_name=libsodium-1.0.16.tar.gz
+$(package)_sha256_hash=eeadc7e1e1bcef09680fb4837d448fbdf57224978f865ac1c16745868fbd0533
 $(package)_dependencies=
 $(package)_config_opts=
 


### PR DESCRIPTION
Path to libsodium 1.0.11 changed on their server and this PR should use latest libsodium library. Compiling Hush with latest libsodium worked and is running fine on my node. sha256 was generated on my own once I donwloaded the file to my laptop. I assume this is not the correct way, libsodium project uses minsign tool to sign/verify packages...